### PR TITLE
fix: no longer break on resource links and add option to filter on re…

### DIFF
--- a/databuilder/databuilder/extractor/glue_extractor.py
+++ b/databuilder/databuilder/extractor/glue_extractor.py
@@ -63,15 +63,15 @@ class GlueExtractor(Extractor):
                     ))
                     i += 1
 
-                yield TableMetadata(
-                    'glue',
-                    self._cluster,
-                    row['DatabaseName'],
-                    row['Name'],
-                    row.get('Description') or row.get('Parameters', {}).get('comment'),
-                    columns,
-                    row.get('TableType') == 'VIRTUAL_VIEW',
-                )
+            yield TableMetadata(
+                'glue',
+                self._cluster,
+                row['DatabaseName'],
+                row['Name'],
+                row.get('Description') or row.get('Parameters', {}).get('comment'),
+                columns,
+                row.get('TableType') == 'VIRTUAL_VIEW',
+            )
 
     def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
@@ -87,6 +87,7 @@ class GlueExtractor(Extractor):
         if self._filters is not None:
             kwargs['Filters'] = self._filters
             kwargs['MaxResults'] = self._max_results
+        if self._resource_share_type:
             kwargs['ResourceShareType'] = self._resource_share_type
         data = self._glue.search_tables(**kwargs)
         tables += data['TableList']

--- a/databuilder/databuilder/extractor/glue_extractor.py
+++ b/databuilder/databuilder/extractor/glue_extractor.py
@@ -52,16 +52,18 @@ class GlueExtractor(Extractor):
             columns, i = [], 0
 
             # Check if StorageDescriptor field is available in order to not break on resource links
-            if 'StorageDescriptor' in row:
-                for column in row['StorageDescriptor']['Columns'] \
-                        + row.get('PartitionKeys', []):
-                    columns.append(ColumnMetadata(
-                        column['Name'],
-                        column['Comment'] if 'Comment' in column else None,
-                        column['Type'],
-                        i
-                    ))
-                    i += 1
+            if not row.get('StorageDescriptor'):
+                continue
+
+            for column in row['StorageDescriptor']['Columns'] \
+                    + row.get('PartitionKeys', []):
+                columns.append(ColumnMetadata(
+                    column['Name'],
+                    column['Comment'] if 'Comment' in column else None,
+                    column['Type'],
+                    i
+                ))
+                i += 1
 
             yield TableMetadata(
                 'glue',

--- a/databuilder/databuilder/extractor/glue_extractor.py
+++ b/databuilder/databuilder/extractor/glue_extractor.py
@@ -61,7 +61,7 @@ class GlueExtractor(Extractor):
                 continue
 
             for column in row['StorageDescriptor']['Columns'] \
-                          + row.get('PartitionKeys', []):
+                    + row.get('PartitionKeys', []):
                 columns.append(ColumnMetadata(
                     column['Name'],
                     column['Comment'] if 'Comment' in column else None,

--- a/databuilder/databuilder/extractor/glue_extractor.py
+++ b/databuilder/databuilder/extractor/glue_extractor.py
@@ -21,7 +21,12 @@ class GlueExtractor(Extractor):
     FILTER_KEY = 'filters'
     MAX_RESULTS_KEY = 'max_results'
     RESOURCE_SHARE_TYPE = 'resource_share_type'
-    DEFAULT_CONFIG = ConfigFactory.from_dict({CLUSTER_KEY: 'gold', FILTER_KEY: None, MAX_RESULTS_KEY: 500, RESOURCE_SHARE_TYPE: "ALL"})
+    DEFAULT_CONFIG = ConfigFactory.from_dict({
+        CLUSTER_KEY: 'gold',
+        FILTER_KEY: None,
+        MAX_RESULTS_KEY: 500,
+        RESOURCE_SHARE_TYPE: "ALL"
+    })
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(GlueExtractor.DEFAULT_CONFIG)
@@ -56,7 +61,7 @@ class GlueExtractor(Extractor):
                 continue
 
             for column in row['StorageDescriptor']['Columns'] \
-                    + row.get('PartitionKeys', []):
+                          + row.get('PartitionKeys', []):
                 columns.append(ColumnMetadata(
                     column['Name'],
                     column['Comment'] if 'Comment' in column else None,

--- a/databuilder/tests/unit/extractor/test_glue_extractor.py
+++ b/databuilder/tests/unit/extractor/test_glue_extractor.py
@@ -10,6 +10,52 @@ from pyhocon import ConfigFactory
 from databuilder.extractor.glue_extractor import GlueExtractor
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
+test_table = {
+    'Name': 'test_table',
+    'DatabaseName': 'test_schema',
+    'Description': 'a table for testing',
+    'StorageDescriptor': {
+        'Columns': [
+            {
+                'Name': 'col_id1',
+                'Type': 'bigint',
+                'Comment': 'description of id1'
+            },
+            {
+                'Name': 'col_id2',
+                'Type': 'bigint',
+                'Comment': 'description of id2'
+            },
+            {
+                'Name': 'is_active',
+                'Type': 'boolean'
+            },
+            {
+                'Name': 'source',
+                'Type': 'varchar',
+                'Comment': 'description of source'
+            },
+            {
+                'Name': 'etl_created_at',
+                'Type': 'timestamp',
+                'Comment': 'description of etl_created_at'
+            },
+            {
+                'Name': 'ds',
+                'Type': 'varchar'
+            }
+        ]
+    },
+    'PartitionKeys': [
+        {
+            'Name': 'partition_key1',
+            'Type': 'string',
+            'Comment': 'description of partition_key1'
+        },
+    ],
+    'TableType': 'EXTERNAL_TABLE',
+}
+
 
 # patch whole class to avoid actually calling for boto3.client during tests
 @patch('databuilder.extractor.glue_extractor.boto3.client', lambda x: None)
@@ -98,51 +144,7 @@ class TestGlueExtractor(unittest.TestCase):
     def test_extraction_with_multiple_result(self) -> None:
         with patch.object(GlueExtractor, '_search_tables') as mock_search:
             mock_search.return_value = [
-                {
-                    'Name': 'test_table1',
-                    'DatabaseName': 'test_schema1',
-                    'Description': 'test table 1',
-                    'StorageDescriptor': {
-                        'Columns': [
-                            {
-                                'Name': 'col_id1',
-                                'Type': 'bigint',
-                                'Comment': 'description of col_id1'
-                            },
-                            {
-                                'Name': 'col_id2',
-                                'Type': 'bigint',
-                                'Comment': 'description of col_id2'
-                            },
-                            {
-                                'Name': 'is_active',
-                                'Type': 'boolean'
-                            },
-                            {
-                                'Name': 'source',
-                                'Type': 'varchar',
-                                'Comment': 'description of source'
-                            },
-                            {
-                                'Name': 'etl_created_at',
-                                'Type': 'timestamp',
-                                'Comment': 'description of etl_created_at'
-                            },
-                            {
-                                'Name': 'ds',
-                                'Type': 'varchar'
-                            }
-                        ]
-                    },
-                    'PartitionKeys': [
-                        {
-                            'Name': 'partition_key1',
-                            'Type': 'string',
-                            'Comment': 'description of partition_key1'
-                        },
-                    ],
-                    'TableType': 'EXTERNAL_TABLE',
-                },
+                test_table,
                 {
                     'Name': 'test_table2',
                     'DatabaseName': 'test_schema1',
@@ -243,51 +245,7 @@ class TestGlueExtractor(unittest.TestCase):
     def test_extraction_with_resource_link_result(self) -> None:
         with patch.object(GlueExtractor, '_search_tables') as mock_search:
             mock_search.return_value = [
-                {
-                    'Name': 'test_table',
-                    'DatabaseName': 'test_schema',
-                    'Description': 'a table for testing',
-                    'StorageDescriptor': {
-                        'Columns': [
-                            {
-                                'Name': 'col_id1',
-                                'Type': 'bigint',
-                                'Comment': 'description of id1'
-                            },
-                            {
-                                'Name': 'col_id2',
-                                'Type': 'bigint',
-                                'Comment': 'description of id2'
-                            },
-                            {
-                                'Name': 'is_active',
-                                'Type': 'boolean'
-                            },
-                            {
-                                'Name': 'source',
-                                'Type': 'varchar',
-                                'Comment': 'description of source'
-                            },
-                            {
-                                'Name': 'etl_created_at',
-                                'Type': 'timestamp',
-                                'Comment': 'description of etl_created_at'
-                            },
-                            {
-                                'Name': 'ds',
-                                'Type': 'varchar'
-                            }
-                        ]
-                    },
-                    'PartitionKeys': [
-                        {
-                            'Name': 'partition_key1',
-                            'Type': 'string',
-                            'Comment': 'description of partition_key1'
-                        },
-                    ],
-                    'TableType': 'EXTERNAL_TABLE',
-                },
+                test_table,
                 {
                     "Name": "test_resource_link",
                     "DatabaseName": "test_schema",

--- a/databuilder/tests/unit/extractor/test_glue_extractor.py
+++ b/databuilder/tests/unit/extractor/test_glue_extractor.py
@@ -210,9 +210,9 @@ class TestGlueExtractor(unittest.TestCase):
             extractor = GlueExtractor()
             extractor.init(self.conf)
 
-            expected = TableMetadata('glue', 'gold', 'test_schema1', 'test_table1', 'test table 1',
-                                     [ColumnMetadata('col_id1', 'description of col_id1', 'bigint', 0),
-                                      ColumnMetadata('col_id2', 'description of col_id2', 'bigint', 1),
+            expected = TableMetadata('glue', 'gold', 'test_schema', 'test_table', 'a table for testing',
+                                     [ColumnMetadata('col_id1', 'description of id1', 'bigint', 0),
+                                      ColumnMetadata('col_id2', 'description of id2', 'bigint', 1),
                                       ColumnMetadata('is_active', None, 'boolean', 2),
                                       ColumnMetadata('source', 'description of source', 'varchar', 3),
                                       ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),

--- a/databuilder/tests/unit/extractor/test_glue_extractor.py
+++ b/databuilder/tests/unit/extractor/test_glue_extractor.py
@@ -240,6 +240,81 @@ class TestGlueExtractor(unittest.TestCase):
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
+    def test_extraction_with_resource_link_result(self) -> None:
+        with patch.object(GlueExtractor, '_search_tables') as mock_search:
+            mock_search.return_value = [
+                {
+                    'Name': 'test_table',
+                    'DatabaseName': 'test_schema',
+                    'Description': 'a table for testing',
+                    'StorageDescriptor': {
+                        'Columns': [
+                            {
+                                'Name': 'col_id1',
+                                'Type': 'bigint',
+                                'Comment': 'description of id1'
+                            },
+                            {
+                                'Name': 'col_id2',
+                                'Type': 'bigint',
+                                'Comment': 'description of id2'
+                            },
+                            {
+                                'Name': 'is_active',
+                                'Type': 'boolean'
+                            },
+                            {
+                                'Name': 'source',
+                                'Type': 'varchar',
+                                'Comment': 'description of source'
+                            },
+                            {
+                                'Name': 'etl_created_at',
+                                'Type': 'timestamp',
+                                'Comment': 'description of etl_created_at'
+                            },
+                            {
+                                'Name': 'ds',
+                                'Type': 'varchar'
+                            }
+                        ]
+                    },
+                    'PartitionKeys': [
+                        {
+                            'Name': 'partition_key1',
+                            'Type': 'string',
+                            'Comment': 'description of partition_key1'
+                        },
+                    ],
+                    'TableType': 'EXTERNAL_TABLE',
+                },
+                {
+                    "Name": "test_resource_link",
+                    "DatabaseName": "test_schema",
+                    "TargetTable": {
+                        "CatalogId": "111111111111",
+                        "DatabaseName": "test_schema_external",
+                        "Name": "test_table"
+                    },
+                    "CatalogId": "222222222222"
+                }
+            ]
+
+            extractor = GlueExtractor()
+            extractor.init(self.conf)
+            actual = extractor.extract()
+            expected = TableMetadata('glue', 'gold', 'test_schema', 'test_table', 'a table for testing',
+                                     [ColumnMetadata('col_id1', 'description of id1', 'bigint', 0),
+                                      ColumnMetadata('col_id2', 'description of id2', 'bigint', 1),
+                                      ColumnMetadata('is_active', None, 'boolean', 2),
+                                      ColumnMetadata('source', 'description of source', 'varchar', 3),
+                                      ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
+                                      ColumnMetadata('ds', None, 'varchar', 5),
+                                      ColumnMetadata('partition_key1', 'description of partition_key1', 'string', 6),
+                                      ], False)
+            self.assertEqual(expected.__repr__(), actual.__repr__())
+            self.assertIsNone(extractor.extract())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix: no longer break on resource links and add option to filter on resource type

### Summary of Changes

- [Resource links](https://docs.aws.amazon.com/lake-formation/latest/dg/create-resource-link-database.html) do not include the 'StorageDescriptor' field. As the code was always trying to extract this field, it would break on resource links.
- Add the option to pass `resource-share-type` in order to specify in what tables a user is interested (all or only foreign)

### Tests
A test was added to verify that resource links no longer break the logic.

### Documentation
Important note: at the moment, AWS provides a different response for resource links when calling the [_search-tables_ API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.search_tables) depending on the value you provide for `resource-share-type` argument:
- "ALL" (default) it only gives a short description without table information
```
{
            "Name": "some_resource_link",
            "DatabaseName": "default",
            "CreateTime": "2021-10-22T13:26:29+02:00",
            "UpdateTime": "2021-10-22T13:26:29+02:00",
            "Retention": 0,
            "CreatedBy": "arn:aws:******************",
            "IsRegisteredWithLakeFormation": false,
            "TargetTable": {
                "CatalogId": "111111111111",
                "DatabaseName": "default_external",
                "Name": "test_table"
            },
            "CatalogId": "222222222222"
}
```
- "FOREING" it gives a full description of foreign tables (including table information)
```
{
            "Name": "test_table_internal",
            "DatabaseName": "default",
            "Owner": "hadoop",
            "CreateTime": "2021-03-07T21:01:06+01:00",
            "UpdateTime": "2021-03-07T21:01:06+01:00",
            "Retention": 0,
            "StorageDescriptor": {
                "Columns": [
                    {
                        "Name": "col1",
                        "Type": "string"
                    },
                    ...
                ],
                "Location": "s3://**********",
                ...
            },
            "PartitionKeys": [],
            "TableType": "EXTERNAL_TABLE",
            "Parameters": {
                "EXTERNAL": "TRUE",
                "has_encrypted_data": "false",
                "transient_lastDdlTime": "1615147266"
            },
            "CreatedBy": "arn:aws:******************",
            "IsRegisteredWithLakeFormation": false,
            "CatalogId": "222222222222"
}
```

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
