### PR TITLE
Fix/sync with es v710

### DIFF
--- a/databuilder/databuilder/models/user_elasticsearch_document.py
+++ b/databuilder/databuilder/models/user_elasticsearch_document.py
@@ -25,10 +25,10 @@ class UserESDocument(ElasticsearchDocument):
                  total_own: int,
                  total_follow: int,
                  ) -> None:
-        self.email = email
+        self.key = email # in new Amundsen document mapping, key is email
         self.first_name = first_name
         self.last_name = last_name
-        self.full_name = full_name
+        self.name = full_name # in new Amundsen document mapping, name is full name
         self.github_username = github_username
         self.team_name = team_name
         self.employee_type = employee_type

--- a/databuilder/databuilder/models/user_elasticsearch_document.py
+++ b/databuilder/databuilder/models/user_elasticsearch_document.py
@@ -25,10 +25,10 @@ class UserESDocument(ElasticsearchDocument):
                  total_own: int,
                  total_follow: int,
                  ) -> None:
-        self.key = email # in new Amundsen document mapping, key is email
+        self.key = email  # in new Amundsen document mapping, key is email
         self.first_name = first_name
         self.last_name = last_name
-        self.name = full_name # in new Amundsen document mapping, name is full name
+        self.name = full_name  # in new Amundsen document mapping, name is full name
         self.github_username = github_username
         self.team_name = team_name
         self.employee_type = employee_type

--- a/databuilder/databuilder/transformer/model_to_dict.py
+++ b/databuilder/databuilder/transformer/model_to_dict.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import json
 from typing import Any, Dict
 
 from pyhocon import ConfigTree
 
-from databuilder.transformer.base_transformer import Transformer
 from databuilder.models.elasticsearch_document import ElasticsearchDocument
-import json
+from databuilder.transformer.base_transformer import Transformer
 
 
 class ModelToDictTransformer(Transformer):

--- a/databuilder/databuilder/transformer/model_to_dict.py
+++ b/databuilder/databuilder/transformer/model_to_dict.py
@@ -1,0 +1,32 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import Any, Dict
+
+from pyhocon import ConfigTree
+
+from databuilder.transformer.base_transformer import Transformer
+from databuilder.models.elasticsearch_document import ElasticsearchDocument
+import json
+
+
+class ModelToDictTransformer(Transformer):
+    """
+    Transforms model into dictionary.
+    For now we are passing it to SearchMetadatatoElasticasearchTask as transformer to
+    convert TableESDocument's and UserESDocument's properties to dictionary.
+    """
+
+    def init(self, conf: ConfigTree) -> None:
+        pass
+
+    def transform(self, record: ElasticsearchDocument) -> Dict[str, Any]:
+        """
+        Return properties of a ElasticsearchDocument instance (EX: TableESDocument)
+        as a dictionary.
+        """
+        return json.loads(record.to_json())
+
+    def get_scope(self) -> str:
+        return 'transformer.model_to_dict'

--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-elasticsearch>=6.2.0,<8.0
+elasticsearch==7.13.0 # Should use this version to work with AWS OpenSearch 7.10 
 elasticsearch-dsl==7.4.0
 neo4j-driver>=1.7.2,<2.0
 requests>=2.25.0,<3.0

--- a/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
+++ b/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
@@ -136,10 +136,10 @@ class MyTestCase(unittest.TestCase):
         manager = User(rk='test_manager_key', email='test_manager@email.com')
         user.manager = manager
 
-        expected_dict = dict(email='test_user@email.com',
+        expected_dict = dict(key='test_user@email.com',
                              first_name='test_first_name',
                              last_name='test_last_name',
-                             full_name='test_full_name',
+                             name='test_full_name',
                              github_username='test_github_username',
                              team_name='test_team_name',
                              employee_type='test_employee_type',

--- a/databuilder/tests/unit/transformer/test_model_to_dict_transformer.py
+++ b/databuilder/tests/unit/transformer/test_model_to_dict_transformer.py
@@ -1,17 +1,17 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import unittest
 
 from databuilder.models.user_elasticsearch_document import UserESDocument
+from databuilder.transformer.model_to_dict import ModelToDictTransformer
 
 
-class TestUserElasticsearchDocument(unittest.TestCase):
+class TestModelToDictTransformer(unittest.TestCase):
 
-    def test_to_json(self) -> None:
+    def test_to_dict(self) -> None:
         """
-        Test string generated from to_json method
+        Test dictionary generated from ModelToDict transformer
         """
         test_obj = UserESDocument(email='test@email.com',
                                   first_name='test_firstname',
@@ -44,10 +44,7 @@ class TestUserElasticsearchDocument(unittest.TestCase):
                                   "key": "test@email.com",
                                   }
 
-        result = test_obj.to_json()
-        results = result.split("\n")
+        transformer = ModelToDictTransformer()
+        result = transformer.transform(test_obj)
 
-        # verify two new line characters in result
-        self.assertEqual(len(results), 2, "Result from to_json() function doesn't have a newline!")
-
-        self.assertDictEqual(json.loads(results[0]), expected_document_dict)
+        self.assertEqual(result, expected_document_dict)


### PR DESCRIPTION
### Summary of Changes

This pull request will fix the problems regarding using the new Amundsen with the AWS OpenSearch Version 7.10:

- Fix ElasticSearch client version which currently only version 7.13.0 works with AWS OpenSearch Version 7.10
- Fix `UserESDocument`'s properties names to be in sync with the new ones in document mapping
- Add a new ModelToDict transformer to convert `TableESDocument` and `UserESDocument` to their dictionary format to later use it in new `SearchMetadatatoElasticasearchTask` task.

### Tests

- Update test for `UserESDocument`'s new namings
- Add test for new `ModelToDict` transformer

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
