### PR TITLE
Feature/neo4j matadata on neptune

### DIFF
--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -1688,6 +1688,89 @@ class TestNeo4jProxy(unittest.TestCase):
                               uri='invalid_feat_uri',
                               resource_type=ResourceType.Feature)
 
+    def test_null_convert_to_none_successfully(self) -> None:
+        """
+        Test all of the `null`s inside dictionary converts to `None` successfully
+        """
+        input = {
+            "problems": [{
+                "Diabetes": [{
+                    "medications": [{
+                        "medicationsClasses": [{
+                            "className": [{
+                                "associatedDrug": [{
+                                    "name": "asprin",
+                                    "dose": "",
+                                    "strength": "null"
+                                }],
+                                "associatedDrug#2": [{
+                                    "name": "somethingElse",
+                                    "dose": "null",
+                                    "strength": "null"
+                                }]
+                            }],
+                            "className2": [{
+                                "associatedDrug": [{
+                                    "name": "asprin",
+                                    "dose": "",
+                                    "strength": "500 mg"
+                                }],
+                                "associatedDrug#2": [{
+                                    "name": "null",
+                                    "dose": "",
+                                    "strength": "500 mg"
+                                }]
+                            }]
+                        }]
+                    }],
+                    "labs": [{
+                        "missing_field": "null"
+                    }]
+                }],
+                "Asthma": [{}]
+            }]}
+
+        expected = {
+            "problems": [{
+                "Diabetes": [{
+                    "medications": [{
+                        "medicationsClasses": [{
+                            "className": [{
+                                "associatedDrug": [{
+                                    "name": "asprin",
+                                    "dose": "",
+                                    "strength": None
+                                }],
+                                "associatedDrug#2": [{
+                                    "name": "somethingElse",
+                                    "dose": None,
+                                    "strength": None
+                                }]
+                            }],
+                            "className2": [{
+                                "associatedDrug": [{
+                                    "name": "asprin",
+                                    "dose": "",
+                                    "strength": "500 mg"
+                                }],
+                                "associatedDrug#2": [{
+                                    "name": None,
+                                    "dose": "",
+                                    "strength": "500 mg"
+                                }]
+                            }]
+                        }]
+                    }],
+                    "labs": [{
+                        "missing_field": None
+                    }]
+                }],
+                "Asthma": [{}]
+            }]}
+
+        actual = Neo4jProxy.convert_null_to_none(input)
+        self.assertEqual(actual, expected)
+
 
 class TestNeo4jProxyHelpers:
     CreateAppsTestCase = namedtuple('CreateAppsTestCase',


### PR DESCRIPTION
### Summary of Changes

With this changes we will be able to use Neo4J proxy with Neptune's OpenCypher in metadata.


### Tests
Added for `null` to `None` converter functionality.

### Documentation
Nothing addded.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
